### PR TITLE
Add RustMEOS and change title of the bindings

### DIFF
--- a/content/bindings/gomeos.md
+++ b/content/bindings/gomeos.md
@@ -1,5 +1,5 @@
 ---
-title: "GoMEOS"
+title: "Go"
 date: 2024-08-31T12:26:38+02:00
 draft: false
 ---

--- a/content/bindings/jmeos.md
+++ b/content/bindings/jmeos.md
@@ -1,5 +1,5 @@
 ---
-title: "JMEOS"
+title: "Java"
 date: 2024-08-31T12:13:56+02:00
 draft: false
 ---

--- a/content/bindings/pymeos.md
+++ b/content/bindings/pymeos.md
@@ -1,12 +1,12 @@
 ---
-title: "PyMEOS"
+title: "Python"
 date: 2024-08-20T13:56:09+02:00
 draft: false
 ---
 
-PyMEOS binding.
+PyMEOS contains the Python bindings of MEOS.
 
-Short description and mayb installation process: TODO
+[comment]: <> (Short description and maybe installation process: TODO)
 
 Link to docs: https://pymeos.readthedocs.io/en/latest/
 

--- a/content/bindings/rustmeos.md
+++ b/content/bindings/rustmeos.md
@@ -1,0 +1,26 @@
+---
+title: "RustMEOS"
+date: 2024-09-11T12:26:38+02:00
+draft: false
+---
+
+[RustMEOS](https://crates.io/crates/meos) is a crate that wraps the MEOS C library, providing a high level interface to the underlying C functionality, without compromising in performance.
+
+RustMEOS exposes the functionality of MEOS and is meant to be used directly by the user.
+
+## Disclaimer
+
+The crate is still in alpha, this means it is not advised for production usage as some tests are still to be added and not proper CI workflows are inplace. 
+
+Only a subset of `meos` has been implemented, feel free to add wrappers for missing features.
+
+All added features needs to be tested and this being a C wrapper, valgrind runs on all examples/tests to check that
+no bugs / memory leaks are lurking.
+
+## Links
+
+GitHub repository: https://github.com/MobilityDB/RustMEOS
+
+Examples: https://github.com/MobilityDB/RustMEOS/tree/main/examples
+
+Documentation: https://docs.rs/meos/0.1.2/meos/

--- a/content/bindings/rustmeos.md
+++ b/content/bindings/rustmeos.md
@@ -1,5 +1,5 @@
 ---
-title: "RustMEOS"
+title: "Rust"
 date: 2024-09-11T12:26:38+02:00
 draft: false
 ---

--- a/data/menu/main.yaml
+++ b/data/menu/main.yaml
@@ -12,12 +12,14 @@ main:
   - name: Bindings
     ref: "/bindings/"
     sub:
-      - name: PyMEOS
+      - name: Python
         ref: "/bindings/pymeos"
-      - name: JMEOS
+      - name: Java
         ref: "/bindings/jmeos"
-      - name: GoMEOS
+      - name: Go
         ref: "/bindings/gomeos"
+      - name: Rust
+        ref: "/bindings/rustmeos"
   - name: Documentation
     # ref: "/documentation"
     sub:


### PR DESCRIPTION
# Added RustMEOS and changed title of the bindings
I changed the title of the bindings since for external users I believe it's more useful to know the language of the binding and not the name of the package as such.


![image](https://github.com/user-attachments/assets/0cce5851-bce6-439d-b5a5-842e9c6bc6b0)
