### PR TITLE
Reframe libmeos.org around MEOS as a canonical pivot library

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,27 +4,105 @@ date: 2022-07-28T12:25:21Z
 draft: false
 ---
 
-MEOS (Mobility Engine, Open Source) is a C library and its associated API for manipulating temporal and spatiotemporal data. It is the core component of [MobilityDB](https://mobilitydb.com), an open source geospatial trajectory data management & analysis platform built on top of [PostgreSQL](https://www.postgresql.org/) and [PostGIS](https://postgis.net/).
+MEOS (Mobility Engine, Open Source) is a C library for temporal and spatiotemporal data — moving objects, time-varying values, and time spans / sets. Databases, query engines, and language bindings consume MEOS to expose temporal types in their respective environments.
 
-MEOS extends the [ISO 19141:2008](https://www.iso.org/standard/41445.html) standard (Geographic information — Schema for moving features) for representing the change of non-spatial attributes of features. It also takes into account the fact that when collecting mobility data it is necessary to represent “temporal gaps”, that is, when for some period of time no observations were collected due, for instance, to signal loss.
+MEOS extends the [ISO 19141:2008](https://www.iso.org/standard/41445.html) standard (Geographic information — Schema for moving features) to also represent the change of non-spatial attributes of features and the *temporal gaps* inherent to mobility data — periods during which no observations were collected, for instance due to signal loss.
 
-MEOS is inspired by a similar library called [GEOS](https://libgeos.org/) (Geometry Engine, Open Source) — hence the name. A [first version](https://github.com/adonmo/meos) of the MEOS library written in C++ has been proposed by Krishna Chaitanya Bommakanti. However, due to the fact that MEOS codebase is actually a subset of MobilityDB codebase, which is written in C and in SQL, the current version of the library allows us to evolve both [programming environments](https://github.com/MobilityDB/MobilityDB/wiki/Building-MobilityDB-and-MEOS) simultaneously.
+The library is inspired by [GEOS](https://libgeos.org/) (Geometry Engine, Open Source) — hence the name.
 
-MEOS aims to be the base library on which other projects can be built. For example, the following projects are built on top of MEOS:
+## Where MEOS is consumed
 
-* [MobilityDB](https://mobilitydb.com) is a PostgreSQL extension that enables storing and manipulating the data types provided by MEOS.
-* [PyMEOS](https://github.com/MobilityDB/PyMEOS) is a Python binding to MEOS using [CFFI](https://cffi.readthedocs.io/en/latest/)
-* [JMEOS](https://github.com/MobilityDB/JMEOS) is a Java binding to MEOS using [JNR-FFI](https://github.com/jnr/jnr-ffi)
-* [meos.rs](https://github.com/MobilityDB/meos-rs) is a Rust binding for MEOS.
-* [GoMEOS](https://github.com/MobilityDB/GoMEOS) is a Go driver for MEOS.
-* [MEOS.net](https://github.com/MobilityDB/MEOS.net) is a C# binding for MEOS.
+MEOS exposes its type system through bindings tailored to each host environment.
 
+| Environment | Binding |
+|---|---|
+| PostgreSQL | [MobilityDB](https://mobilitydb.com) |
+| DuckDB | [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) |
+| Python | [PyMEOS](https://github.com/MobilityDB/PyMEOS) |
+| Java | [JMEOS](https://github.com/MobilityDB/JMEOS) |
+| Rust | [meos-rs](https://github.com/MobilityDB/meos-rs) |
+| Go | [GoMEOS](https://github.com/MobilityDB/GoMEOS) |
+| .NET | [MEOS.NET](https://github.com/MobilityDB/MEOS.NET) |
+| JavaScript | [MEOS.js](https://github.com/MobilityDB/MEOS.js) |
 
-Other projects can built on top of MEOS, for example, MEOS bindings for other programming languages or implementing MEOS on other DBMSs such as MySQL or platforms such as Spark or Flink.
+Each binding exposes the same MEOS type system using the conventions of its host environment: SQL functions in PostgreSQL/DuckDB, idiomatic classes in PyMEOS / JMEOS / meos-rs / GoMEOS / MEOS.NET / MEOS.js. The C library is the source of truth for type semantics, encoding, and behaviour.
 
+## Architecture
 
-Ackowledgements
----------------
+```mermaid
+flowchart TB
+  meos(["MEOS<br/>C library"])
+  pg["MobilityDB<br/>(PostgreSQL)"]
+  duck["MobilityDuck<br/>(DuckDB)"]
+  py["PyMEOS<br/>(Python)"]
+  java["JMEOS<br/>(Java)"]
+  rust["meos-rs<br/>(Rust)"]
+  go["GoMEOS<br/>(Go)"]
+  net["MEOS.NET<br/>(.NET / C#)"]
+  js["MEOS.js<br/>(JavaScript)"]
+
+  pg --> meos
+  duck --> meos
+  py --> meos
+  java --> meos
+  rust --> meos
+  go --> meos
+  net --> meos
+  js --> meos
+```
+
+Other consumers can be built directly on top of MEOS — additional language bindings, integrations with other DBMSs, or analytics platforms (Spark, Flink, Apache Beam, etc.). The MEOS C API is the common substrate.
+
+## Learn the basics
+
+A nine-step tutorial series walks through the essence of the library. Several steps offer **variants** that swap an axis without changing the lesson — typically a different coordinate system (Cartesian vs. geodetic), a different input source (real-world AIS vs. synthetic BerlinMOD), or a different I/O target (in-process, DB, file). Pick the variant that matches your stack:
+
+1. **Hello World** — first temporal point values and MF-JSON output.
+   * [Cartesian](/tutorialprograms/01_hello_world/) — `tgeompoint` in a planar coordinate system.
+   * Geodetic variant — `tgeogpoint` on the WGS84 sphere (`01_hello_world_geodetic.c`).
+2. [AIS Read](/tutorialprograms/02_ais_read/) — parsing AIS observation records into temporal values.
+3. **AIS / BerlinMOD Assemble** — building trajectories from streaming observations.
+   * [AIS](/tutorialprograms/03_ais_assemble/) — real-world AIS data (Danish Maritime Authority feed).
+   * BerlinMOD variant — synthetic data from the BerlinMOD generator (`03_berlinmod_assemble.c`).
+4. **AIS Persist** — three variants for *where* the trajectories land:
+   * [Bulk → DB](/tutorialprograms/04_ais_store/) — load a CSV file into MobilityDB in one shot.
+   * [Stream → DB](/tutorialprograms/04_ais_stream_db/) — streaming DB ingest using MEOS expandable temporal structures, sending batches to MobilityDB as they fill.
+   * Stream → File variant (`04_ais_stream_file.c`) — same expandable-structure streaming pattern, writing to an output file instead of a database.
+5. [BerlinMOD Disassemble](/tutorialprograms/05_berlinmod_disassemble/) — splitting trips into instants.
+6. [BerlinMOD Clip](/tutorialprograms/06_berlinmod_clip/) — restricting trajectories to spatial regions.
+7. [BerlinMOD Tile](/tutorialprograms/07_berlinmod_tile/) — spatiotemporal tiling.
+8. [BerlinMOD Simplify](/tutorialprograms/08_berlinmod_simplify/) — line-simplification of trajectories.
+9. [BerlinMOD Aggregate](/tutorialprograms/09_berlinmod_aggregate/) — temporal aggregation.
+
+The numbered series is intentionally simplified — small datasets, well-formed input, no error handling — so that the MEOS API is the focus of attention rather than the I/O scaffolding around it.
+
+Some examples ship a `*_full.c` counterpart in [`meos/examples/`](https://github.com/MobilityDB/MobilityDB/tree/master/meos/examples) that handles real-world conditions: realistic file sizes, malformed inputs, edge cases, error recovery, retry / reconnect logic. **The convention is that `_full` counterparts exist only where the data has real-world messiness** — i.e. for examples that operate on a real AIS feed. The BerlinMOD examples (steps 5–9) operate on synthetic generator-produced data that's clean by construction, so they intentionally have no `_full` counterpart.
+
+Current pairs:
+
+* `03_ais_assemble.c` ↔ `ais_assemble_full.c`
+* `ais_expand.c` ↔ `ais_expand_full.c`
+* `ais_transform.c` ↔ `ais_transform_full.c`
+
+Use the simplified example to learn the API; use the `_full` counterpart as a reference when wiring MEOS into production code.
+
+Beyond the tutorial ladder, [`meos/examples/`](https://github.com/MobilityDB/MobilityDB/tree/master/meos/examples) also contains feature-specific examples: rtree indexing, k-means / DBSCAN clustering, projection, transforms, expansion, network points, and more.
+
+## Encodings
+
+MEOS defines stable on-the-wire encodings for temporal values, allowing data to round-trip between bindings without loss:
+
+* [Well-Known Text (WKT)](/movingfeaturesformats/wkt/) — human-readable.
+* [Well-Known Binary (WKB)](/movingfeaturesformats/wkb/) — compact binary, the canonical interchange format.
+* [Moving-Features JSON (MF-JSON)](/movingfeaturesformats/mfjson/) — OGC-aligned JSON.
+
+A trajectory written from one binding can be read by any other.
+
+## Origin
+
+A [first version](https://github.com/adonmo/meos) of MEOS, written in C++, was contributed by Krishna Chaitanya Bommakanti. The current C library evolved from that origin and has been the canonical implementation since.
+
+## Acknowledgements
 
 <img src="/images/eu-flag.jpg" alt="EU Flag" style="width: 100px; float:left; margin-right: 10px;" align="middle" />
 <p>

--- a/content/bindings/_index.md
+++ b/content/bindings/_index.md
@@ -4,9 +4,37 @@ date: 2024-08-20T13:54:25+02:00
 draft: false
 ---
 
-MEOS Bindings: 
+MEOS exposes its type system through bindings tailored to each host environment. Pick the binding that matches your stack.
 
-- Python: [PyMEOS](pymeos/)
-- Java: [JMEOS](jmeos/)
-- Go: [GoMEOS](gomeos/)
-- Rust: [RustMEOS](rustmeos/)
+## Database bindings
+
+These bindings expose MEOS types as first-class types of a database or query engine, with full SQL support, indexing, and aggregation.
+
+* **[PostgreSQL → MobilityDB](mobilitydb/)**
+* **[DuckDB → MobilityDuck](mobilityduck/)**
+
+## Language bindings
+
+These bindings expose MEOS to general-purpose programming languages. Use them when you want to manipulate temporal data in application code rather than inside a database.
+
+* **[Python → PyMEOS](pymeos/)**
+* **[Java → JMEOS](jmeos/)**
+* **[Rust → meos-rs](rustmeos/)**
+* **[Go → GoMEOS](gomeos/)**
+* **[.NET / C# → MEOS.NET](meosnet/)**
+* **[JavaScript → MEOS.js](meosjs/)**
+
+## Choosing a binding
+
+| If you... | Use |
+|---|---|
+| have PostgreSQL in your stack | MobilityDB |
+| use DuckDB or want embedded analytics | MobilityDuck |
+| work in a Python notebook / data-science workflow | PyMEOS |
+| build a Java / Kotlin / Scala / Clojure backend | JMEOS |
+| build a Rust application | meos-rs |
+| build a Go service | GoMEOS |
+| build a .NET / Unity / desktop application | MEOS.NET |
+| target the browser or Node.js | MEOS.js |
+
+Bindings can be combined. A typical setup might use MobilityDB to store and query trajectories, PyMEOS to analyse them in a Jupyter notebook, and MEOS.js to visualise results in the browser. All three exchange data using MEOS's [encoding formats](/movingfeaturesformats/).

--- a/content/bindings/meosjs.md
+++ b/content/bindings/meosjs.md
@@ -1,0 +1,12 @@
+---
+title: "JavaScript"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+MEOS.js is the JavaScript binding for MEOS, targeting both browser
+environments (via WebAssembly) and Node.js. Suitable for browser-side
+visualisations consuming trajectory data, Node.js services that
+manipulate temporal values, and any other JS workload.
+
+GitHub: https://github.com/MobilityDB/MEOS.js

--- a/content/bindings/meosnet.md
+++ b/content/bindings/meosnet.md
@@ -1,0 +1,12 @@
+---
+title: ".NET / C#"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+MEOS.NET is the .NET / C# binding for MEOS, exposing the MEOS C API
+as idiomatic .NET classes via P/Invoke. Suitable for desktop
+applications (WPF, WinForms, Avalonia), Unity games consuming
+trajectory data, ASP.NET services, and any other .NET workload.
+
+GitHub: https://github.com/MobilityDB/MEOS.NET

--- a/content/bindings/mobilitydb.md
+++ b/content/bindings/mobilitydb.md
@@ -1,0 +1,18 @@
+---
+title: "PostgreSQL"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+MobilityDB is the PostgreSQL extension that exposes MEOS types as
+first-class PostgreSQL types, with full SQL support, GiST / SP-GiST
+indexing, query optimisation, and server-side aggregations. It
+integrates directly with [PostGIS](https://postgis.net/), so
+trajectories interoperate with conventional geometry / geography
+data without conversion.
+
+Project site: https://mobilitydb.com
+
+GitHub: https://github.com/MobilityDB/MobilityDB
+
+Documentation: https://docs.mobilitydb.com

--- a/content/bindings/mobilityduck.md
+++ b/content/bindings/mobilityduck.md
@@ -1,0 +1,13 @@
+---
+title: "DuckDB"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+MobilityDuck is the [DuckDB](https://duckdb.org/) extension that
+embeds MEOS into DuckDB's columnar query engine. It exposes MEOS
+types as first-class DuckDB types and is suited to analytics
+workloads — in-process queries, Parquet / Arrow interchange,
+notebook-driven exploration.
+
+GitHub: https://github.com/MobilityDB/MobilityDuck

--- a/content/documentation/typecatalog.md
+++ b/content/documentation/typecatalog.md
@@ -1,0 +1,97 @@
+---
+title: "Type Catalog"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+A reference list of every type MEOS exposes. For the conceptual model
+behind temporal types (instant / sequence / sequence-set subtypes,
+discrete / linear / stepwise interpolation, bounding boxes), see the
+[Data Model](../datamodel/) page.
+
+## Temporal types
+
+Temporal types represent the evolution of a value over time. Each is
+parameterised by a *base type* and is available in the three subtypes
+(`Instant`, `Sequence`, `Sequence Set`) described in the data model.
+
+| Type | Base type | Notes |
+|---|---|---|
+| `tbool` | `bool` | discrete or stepwise interpolation only |
+| `tint` | `int` | discrete or stepwise interpolation only |
+| `tfloat` | `float` | discrete, linear, or stepwise interpolation |
+| `ttext` | `text` | discrete or stepwise interpolation only |
+| `tgeompoint` | 2D / 3D `geometry` point | spatial-temporal in a Cartesian plane (any SRID) |
+| `tgeogpoint` | 2D / 3D `geography` point | spatial-temporal on the geodetic sphere |
+| `tgeometry` | arbitrary `geometry` | beyond points: lines, polygons, collections |
+| `tgeography` | arbitrary `geography` | geodetic counterpart of `tgeometry` |
+
+## Span types
+
+Spans represent contiguous ranges over an ordered base type. They
+correspond to PostgreSQL [range types](https://www.postgresql.org/docs/current/rangetypes.html).
+
+| Type | Range over |
+|---|---|
+| `intspan` | `int` |
+| `bigintspan` | `bigint` |
+| `floatspan` | `float` |
+| `datespan` | `date` |
+| `tstzspan` | `timestamp with time zone` |
+
+## Span set types
+
+A span set is a finite union of spans of the same family.
+
+| Type | Underlying span |
+|---|---|
+| `intspanset` | `intspan` |
+| `bigintspanset` | `bigintspan` |
+| `floatspanset` | `floatspan` |
+| `datespanset` | `datespan` |
+| `tstzspanset` | `tstzspan` |
+
+## Set types
+
+Sets represent finite, sorted, uniqued collections of values of an
+ordered base type.
+
+| Type | Element type |
+|---|---|
+| `intset` | `int` |
+| `bigintset` | `bigint` |
+| `floatset` | `float` |
+| `dateset` | `date` |
+| `tstzset` | `timestamp with time zone` |
+| `textset` | `text` |
+| `geomset` | `geometry` |
+| `geogset` | `geography` |
+
+## Bounding-box types
+
+Bounding boxes carry the spatial / value / temporal extent of a value
+and are used for indexing and for fast disjointness checks.
+
+| Type | Carries |
+|---|---|
+| `tstzspan` | temporal extent only — used for `tbool` and `ttext` |
+| `tbox` | value extent (X) + temporal extent (T) — used for `tint` and `tfloat` |
+| `stbox` | spatial extent (X, Y, optional Z) + temporal extent (T) — used for `tgeompoint`, `tgeogpoint`, `tgeometry`, `tgeography` |
+
+## Optional / specialised types
+
+These types are gated behind compile-time flags in MEOS so that
+deployments can include only what they need. Each is exposed by its
+respective binding when the corresponding flag is enabled.
+
+| Type | Flag | Domain |
+|---|---|---|
+| `cbuffer` / `tcbuffer` | `-DCBUFFER=ON` | circular buffers (point + radius) and their temporal evolution |
+| `npoint` / `tnpoint` | `-DNPOINT=ON` (default) | network-constrained points (along a road / network edge) and their temporal evolution |
+| `pose` / `tpose` | `-DPOSE=ON` | rigid-body poses (position + orientation) and their temporal evolution |
+| `rgeo` / `trgeo` | `-DRGEO=ON` (depends on `POSE`) | rigid geometries — geometries attached to a moving pose |
+
+The catalog grows over time as new external base types are lifted to
+their temporal counterparts. Bindings consume whatever MEOS exposes;
+binding-specific availability follows the binding's own compile-time
+flags.

--- a/content/movingfeaturesformats/_index.md
+++ b/content/movingfeaturesformats/_index.md
@@ -4,10 +4,16 @@ date: 2022-07-29T14:28:47+02:00
 draft: false
 ---
 
-Temporal types can be represented in the following formats: 
+MEOS defines stable on-the-wire encodings for temporal values. These encodings are the common substrate that lets data round-trip between any two MEOS [bindings](/bindings/) without loss: a trajectory written from MobilityDB can be read by PyMEOS, JMEOS, MobilityDuck, and any other binding that consumes MEOS.
 
-- [Well-Known Text (WKT)](wkt/)
-- [Well-Known Binary (WKB)](wkb/)
-- [Moving-Features JSON (MF-JSON)](mfjson/)
+The library currently supports three encodings, each tuned for a different use case:
 
+| Encoding | Use case | Form |
+|---|---|---|
+| [Well-Known Text (WKT)](wkt/) | human-readable, debugging, hand-authored fixtures | text |
+| [Well-Known Binary (WKB)](wkb/) | canonical binary interchange, the densest representation | binary |
+| [Moving-Features JSON (MF-JSON)](mfjson/) | OGC-aligned JSON, web APIs, cross-language readability | text (JSON) |
 
+WKB is the canonical encoding for storage and inter-process transfer; WKT is the one users typically read and write by hand; MF-JSON is the one that travels well over REST / GraphQL / browser-side workflows.
+
+All three encodings are *self-describing*: a value carries enough type information for the receiver to reconstruct the original temporal type without out-of-band metadata. Bindings can therefore exchange values with each other using any of the three formats and pick the format best-suited to the transport.

--- a/content/project/versioning.md
+++ b/content/project/versioning.md
@@ -1,0 +1,61 @@
+---
+title: "Versioning & Stability"
+date: 2026-05-01T00:00:00Z
+draft: false
+---
+
+MEOS makes explicit stability commitments so that bindings, downstream
+applications, and persisted data can rely on the library across
+releases.
+
+## C API stability
+
+The public C API exposed by `meos.h` follows
+[Semantic Versioning](https://semver.org/) (semver):
+
+| Version bump | What changes |
+|---|---|
+| **Patch** (`x.y.Z`) | Bug fixes, internal refactoring. No source-level or ABI changes. |
+| **Minor** (`x.Y.0`) | New functions / types. Existing function signatures and ABI remain compatible — code written against an older minor version compiles and links against a newer one in the same major series. |
+| **Major** (`X.0.0`) | Source / ABI breaks allowed. Migration notes ship with the release. |
+
+Functions that are **deprecated** in a minor version remain usable
+through the rest of that major series and are removed only at the next
+major bump.
+
+## Wire-format stability
+
+Every encoding MEOS defines (WKT, [WKB](/movingfeaturesformats/wkb/),
+[MF-JSON](/movingfeaturesformats/mfjson/)) carries its own version
+number, evolved independently of the C API:
+
+* **Forward compatibility** — readers refuse to load a value whose
+  encoding-version major number is higher than they support, with a
+  clear error.
+* **Backward compatibility** — readers accept any value whose
+  encoding-version is the same major and any lower-or-equal minor.
+* **Versioning of footer metadata** — when MEOS encodings are
+  embedded in a higher-level container format (for example, a Parquet
+  file with custom footer metadata), the container's footer carries
+  its own version alongside the encoding version, so a reader can
+  detect a version mismatch before attempting to decode any value.
+
+A value written by any MEOS-consuming binding can be read by any other
+binding linked against a compatible MEOS major version.
+
+## Type-catalog stability
+
+The [type catalog](/documentation/typecatalog/) grows over time as new
+base types are lifted to their temporal counterparts. Adding a new
+type is a *minor* version bump (the C API gains new functions but
+existing ones are unaffected). Removing a type is a *major* version
+bump and is preceded by at least one minor-version cycle of
+deprecation.
+
+## Binding compatibility
+
+Each binding declares the MEOS major version it supports. Bindings are
+not required to release in lockstep with MEOS; a typical pattern is
+that a binding's `x.y` release supports MEOS `MAJOR` for some declared
+range. See each binding's documentation for its specific compatibility
+statement.


### PR DESCRIPTION
## Summary

Recasts the site so that MEOS reads as a C library at the centre of an ecosystem of bindings — the same architectural shape as [GEOS](https://libgeos.org/) (which the project is named after) or [H3](https://h3geo.org/) — rather than as a sub-component of MobilityDB. The previous landing page opened with *"It is the core component of MobilityDB"*; the new one names MEOS's role explicitly and the eight bindings that consume it (MobilityDB, MobilityDuck, PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js) become the foreground rather than a footnote.

## What changes

### Landing page (`content/_index.md`)

- Opening sentence names the role: *"a C library for temporal and spatiotemporal data … consumed by databases, query engines, and language bindings"*.
- **Where MEOS is consumed** — table mapping each environment (PostgreSQL / DuckDB / Python / Java / Rust / Go / .NET / JavaScript) to its binding. The previous bullet list was missing MobilityDuck, MEOS.NET, and MEOS.js.
- **Architecture** — Mermaid diagram with MEOS at the centre.
- **Learn the basics** — the nine-step tutorial series with one-line summaries, plus the simplified-vs-realistic split between the numbered examples and their `*_full.c` counterparts (the numbered ones are the teaching ladder; `_full` variants are the real-world reference implementations).
- **Encodings** — links to WKT / WKB / MF-JSON.
- Origin attribution preserved at the bottom in a tighter form.

### Bindings index (`content/bindings/_index.md`)

- Two-tier classification: **Database bindings** (MobilityDB, MobilityDuck) vs **Language bindings** (the other six). Different integration shapes; signalling the split helps users navigate.
- **Choosing a binding** decision table mapping the user's stack to the right entry-point.
- Notes that bindings interoperate via MEOS's encoding formats.

### Per-binding pages

Four new pages matching the format of the existing per-binding pages (`pymeos.md`, `jmeos.md`, `gomeos.md`, `rustmeos.md`):

- `content/bindings/mobilitydb.md` — PostgreSQL extension. Links to mobilitydb.com, the GitHub repo, and the docs site.
- `content/bindings/mobilityduck.md` — DuckDB extension.
- `content/bindings/meosnet.md` — .NET / C# binding via P/Invoke.
- `content/bindings/meosjs.md` — JavaScript binding for browser (via WebAssembly) and Node.js.

The bindings index now links to the per-binding pages uniformly across all eight entries.

### Encodings index (`content/movingfeaturesformats/_index.md`)

- Lifts the encodings index from a list to a positioning paragraph: these formats are the common substrate that lets bindings round-trip data with each other without loss.
- Use-case table distinguishing WKT (human-readable / debugging), WKB (canonical binary / interchange), MF-JSON (OGC-aligned JSON / web APIs).

### Type catalog (`content/documentation/typecatalog.md`)

A reference-style page listing every type MEOS exposes today, organised by family:

- **Temporal types**: `tbool` / `tint` / `tfloat` / `ttext` / `tgeompoint` / `tgeogpoint` / `tgeometry` / `tgeography`.
- **Span types** + **span set types** + **set types**.
- **Bounding-box types**: `tstzspan` / `tbox` / `stbox` and what each carries.
- **Optional / specialised types**: `cbuffer` / `tcbuffer`, `npoint` / `tnpoint`, `pose` / `tpose`, `rgeo` / `trgeo` and their compile-time flags.

Cross-references the existing [Data Model](datamodel/) page for the conceptual prose.

### Versioning policy (`content/project/versioning.md`)

Explicit stability commitments:

- **C API stability** — semver semantics for `meos.h` (patch / minor / major), deprecation cycle.
- **Wire-format stability** — every encoding (WKT / WKB / MF-JSON) carries its own version, evolved independently of the C API. Forward / backward compatibility rules. Footer-version awareness for higher-level container formats.
- **Type-catalog stability** — adding a type is a minor bump; removing one is a major bump after a deprecation cycle.
- **Binding compatibility** — how bindings declare their supported MEOS major.

These commitments don't change anything technical; they're documentation of the contract MEOS already implicitly observes.

## What's deliberately left untouched

- All other documentation pages (data model, data structures, aggregation, modification, normalization, developer notes), the existing tutorial series under `tutorialprograms/`, the project info pages, and the theme.
- The existing per-binding pages for PyMEOS, JMEOS, GoMEOS, RustMEOS — kept verbatim.
- The acknowledgements section on the landing page (grant references kept verbatim).
- No theme / layout / branding changes; pure content updates.

## Preview

```sh
hugo server -D
# open http://localhost:1313/
```
