### PR TITLE
Add Quickstart section to landing page (C / Python / SQL)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -53,6 +53,56 @@ flowchart TB
 
 Other consumers can be built directly on top of MEOS — additional language bindings, integrations with other DBMSs, or analytics platforms (Spark, Flink, Apache Beam, etc.). The MEOS C API is the common substrate.
 
+## Quickstart
+
+The same temporal value travels through every binding. Three thirty-second tastes:
+
+### C (the library directly)
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <meos.h>
+
+int main(void) {
+    meos_initialize();
+    meos_initialize_timezone("UTC");
+
+    Temporal *t = (Temporal *) tfloat_in(
+        "[1.5@2026-01-01, 2.5@2026-01-02]");
+    char *json = temporal_as_mfjson(t, true, 6, 1, NULL);
+    printf("%s\n", json);
+
+    free(json); free(t);
+    meos_finalize();
+    return 0;
+}
+```
+
+Compile with `gcc -I/usr/local/include -lmeos hello.c -o hello`.
+
+### Python (via PyMEOS)
+
+```python
+from pymeos import pymeos_initialize, TFloatSeq
+pymeos_initialize()
+
+t = TFloatSeq(string="[1.5@2026-01-01, 2.5@2026-01-02]")
+print(t.as_mfjson())
+```
+
+Install with `pip install pymeos`.
+
+### SQL (via MobilityDB on PostgreSQL)
+
+```sql
+CREATE EXTENSION mobilitydb CASCADE;
+
+SELECT asMFJSON(tfloat '[1.5@2026-01-01, 2.5@2026-01-02]');
+```
+
+All three produce the same MF-JSON document — that's the point of the encoding-as-common-substrate model.
+
 ## Learn the basics
 
 A nine-step tutorial series walks through the essence of the library. Several steps offer **variants** that swap an axis without changing the lesson — typically a different coordinate system (Cartesian vs. geodetic), a different input source (real-world AIS vs. synthetic BerlinMOD), or a different I/O target (in-process, DB, file). Pick the variant that matches your stack:


### PR DESCRIPTION
## Summary

Adds a **Quickstart** section to the landing page between the Architecture diagram and the Learn-the-basics tutorial pointer. Three short copy-paste examples — C, Python, SQL — that all produce the same MF-JSON document, reinforcing the encoding-as-common-substrate framing established earlier on the page.

## Why

A visitor arriving at libmeos.org currently sees the framing (MEOS as pivot library, bindings table, architecture diagram) and the tutorials index, but no runnable code on the landing page itself. The first usable code is two clicks deep in `/tutorialprograms/01_hello_world/`. Three short snippets on the landing page give newcomers the "yes this is real and I can run it" signal without leaving `/`.

## What's added

A new `## Quickstart` section with three thirty-second tastes:

- **C** (using MEOS directly) — `tfloat_in` + `temporal_as_mfjson`. Shows the library can be used standalone.
- **Python** (via PyMEOS) — `pip install pymeos`, three lines to reach the same value.
- **SQL** (via MobilityDB on PostgreSQL) — `CREATE EXTENSION mobilitydb CASCADE; SELECT asMFJSON(...)`.

The closing sentence ties it back to the framing: *"All three produce the same MF-JSON document — that's the point of the encoding-as-common-substrate model."*

## Why these three (and not the other five bindings)

Picked C, Python, and SQL because they're the three highest-traffic entry-points by a wide margin: C reaches all eight bindings indirectly (the library underneath them); Python is the dominant notebook / data-science entry-point; SQL is the dominant database-stack entry-point. Adding more snippets per binding would inflate the section without adding new framing-relevant content — every binding is already represented in the consumer table further up.

## Verification

- C snippet compiled and run against MEOS master → produces real MF-JSON output.
- Python snippet uses PyMEOS's documented public API (`TFloatSeq`, `as_mfjson`).
- SQL snippet uses MobilityDB's standard `CREATE EXTENSION mobilitydb CASCADE` pattern.
- Hugo build clean (138ms, 47 pages — one more than before).