### PR TITLE
Polish pass: standards section, bindings architecture diagram, type-catalog cross-references

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,9 +6,17 @@ draft: false
 
 MEOS (Mobility Engine, Open Source) is a C library for temporal and spatiotemporal data — moving objects, time-varying values, and time spans / sets. Databases, query engines, and language bindings consume MEOS to expose temporal types in their respective environments.
 
-MEOS extends the [ISO 19141:2008](https://www.iso.org/standard/41445.html) standard (Geographic information — Schema for moving features) to also represent the change of non-spatial attributes of features and the *temporal gaps* inherent to mobility data — periods during which no observations were collected, for instance due to signal loss.
-
 The library is inspired by [GEOS](https://libgeos.org/) (Geometry Engine, Open Source) — hence the name.
+
+## Standards alignment
+
+MEOS implements published standards rather than ad-hoc representations:
+
+* [**ISO 19141:2008**](https://www.iso.org/standard/41445.html) — *Geographic information — Schema for moving features.* MEOS extends it to also represent the evolution of non-spatial attributes and the *temporal gaps* inherent to real mobility data (periods during which no observations were collected, for instance due to signal loss).
+* [**OGC Moving Features JSON**](https://docs.opengeospatial.org/is/19-045r3/19-045r3.html) — the canonical JSON encoding for moving features, an extension of [GeoJSON](https://geojson.org/). MEOS implements it as its [MF-JSON encoding](/movingfeaturesformats/mfjson/).
+* **Well-Known Text** and **Well-Known Binary** — the same conventions used by [GEOS](https://libgeos.org/) and [PostGIS](https://postgis.net/), extended to the time dimension. See [WKT](/movingfeaturesformats/wkt/) and [WKB](/movingfeaturesformats/wkb/).
+
+The encoding choice is up to the consumer; values move losslessly between the three so a binding can pick whichever fits its transport.
 
 ## Where MEOS is consumed
 

--- a/content/bindings/_index.md
+++ b/content/bindings/_index.md
@@ -6,6 +6,32 @@ draft: false
 
 MEOS exposes its type system through bindings tailored to each host environment. Pick the binding that matches your stack.
 
+## Architecture
+
+```mermaid
+flowchart TB
+  meos(["MEOS<br/>C library"])
+  pg["MobilityDB<br/>(PostgreSQL)"]
+  duck["MobilityDuck<br/>(DuckDB)"]
+  py["PyMEOS<br/>(Python)"]
+  java["JMEOS<br/>(Java)"]
+  rust["meos-rs<br/>(Rust)"]
+  go["GoMEOS<br/>(Go)"]
+  net["MEOS.NET<br/>(.NET / C#)"]
+  js["MEOS.js<br/>(JavaScript)"]
+
+  pg --> meos
+  duck --> meos
+  py --> meos
+  java --> meos
+  rust --> meos
+  go --> meos
+  net --> meos
+  js --> meos
+```
+
+The C library is the source of truth for type semantics, encoding, and behaviour. Each binding is a language- or system-specific surface over the same underlying types — values written from one binding are readable from any other via the shared [encoding formats](/movingfeaturesformats/).
+
 ## Database bindings
 
 These bindings expose MEOS types as first-class types of a database or query engine, with full SQL support, indexing, and aggregation.

--- a/content/documentation/typecatalog.md
+++ b/content/documentation/typecatalog.md
@@ -95,3 +95,9 @@ The catalog grows over time as new external base types are lifted to
 their temporal counterparts. Bindings consume whatever MEOS exposes;
 binding-specific availability follows the binding's own compile-time
 flags.
+
+For the conceptual model behind these types — instant / sequence /
+sequence-set subtypes, discrete / linear / stepwise interpolation, and
+how bounding boxes work — see the [Data Model](../datamodel/) page.
+For the on-the-wire encoding of values of any type in this catalog,
+see [Moving Feature Formats](/movingfeaturesformats/).


### PR DESCRIPTION
## Summary

Three small additions that tighten the canonical-library positioning without adding new top-level pages.

## What changes

### `content/_index.md` — Standards-alignment section

Lifts the standards-alignment story from scattered prose into a single visible block just below the opening paragraph:

- **ISO 19141:2008** (the conceptual model MEOS extends, with a note about temporal-gap representation).
- **OGC Moving Features JSON** (the canonical JSON encoding MEOS implements).
- **Well-Known Text / Well-Known Binary** (the GEOS / PostGIS conventions, extended to the time dimension).

The previous flowing-prose sentence on ISO 19141 is absorbed into the new section's first bullet — no information is lost; it's just made more visible. Closing line ties back to the encoding-as-common-substrate framing.

### `content/bindings/_index.md` — Architecture diagram

Adds the MEOS-at-the-centre Mermaid diagram (the same one already on the landing page) so visitors who arrive directly at `/bindings/` (e.g. via search) get the pivot-library framing without backing out to `/`. Brief paragraph following the diagram reinforces "C library is the source of truth; bindings are surfaces over it".

### `content/documentation/typecatalog.md` — Closing cross-references

Adds a small two-link block at the bottom of the type catalog pointing readers at:
- The [Data Model](../datamodel/) page for the conceptual prose (subtypes, interpolation, bounding boxes).
- The [Moving Feature Formats](/movingfeaturesformats/) index for on-the-wire encodings.

Catches users who scrolled past the end of the catalog table looking for "what next?".

## Verification

- Hugo build clean (160 ms, 47 pages).
- Standards-alignment section renders correctly on `/`.
- Architecture diagram renders on `/bindings/` (Mermaid block, same shape as landing).
- Type-catalog cross-reference block renders at the bottom of `/documentation/typecatalog/`.
