### PR TITLE
ci: install Dart Sass from GitHub releases instead of snap

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,7 +39,19 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        env:
+          DART_SASS_VERSION: 1.79.4
+        run: |
+          # Install Dart Sass directly from its GitHub release tarball
+          # rather than via snap. The snap install path has had
+          # availability issues ("error: unable to contact snap store");
+          # the GitHub releases CDN is more reliable.
+          wget -qO /tmp/dart-sass.tar.gz \
+            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+          sudo tar -xzf /tmp/dart-sass.tar.gz -C /opt
+          sudo ln -sf /opt/dart-sass/dart-sass /usr/local/bin/dart-sass
+          rm /tmp/dart-sass.tar.gz
+          dart-sass --version
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Replace `sudo snap install dart-sass` with a direct GitHub-releases download to stop the deploy workflow being held hostage to snap-store availability.

## Problem

The current Pages deploy workflow has been failing with:

```
error: unable to contact snap store
##[error]Process completed with exit code 1.
```

This has been observed in two consecutive `master`-branch deploys (runs `25207982727` and `25208178457`), both at the `Install Dart Sass` step. The failure happens during `sudo snap install dart-sass`, when the runner can't reach Canonical's snap-store servers. It's a single-vendor availability dependency that periodically takes down the deploy despite no content change in the site.

## Fix

Install Dart Sass directly from its [GitHub releases](https://github.com/sass/dart-sass/releases/) tarball instead of via snap. GitHub releases are multi-CDN-backed and have not had a comparable outage. Pin to `DART_SASS_VERSION=1.79.4` so the build is deterministic; bump intentionally when there's a reason to.

The replacement step:

```yaml
- name: Install Dart Sass
  env:
    DART_SASS_VERSION: 1.79.4
  run: |
    wget -qO /tmp/dart-sass.tar.gz \
      "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
    sudo tar -xzf /tmp/dart-sass.tar.gz -C /opt
    sudo ln -sf /opt/dart-sass/dart-sass /usr/local/bin/dart-sass
    rm /tmp/dart-sass.tar.gz
    dart-sass --version
```

## Verification

- YAML is valid (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hugo.yml'))"`).
- The `dart-sass --version` line at the end of the install confirms the binary is on PATH and runnable; the build step's `hugo --gc --minify` will use it transparently.
- After this PR merges, the failed deploys for the recent content merges (PRs #8, #9) can be re-triggered via `gh run rerun` and should go through.
