### PR TITLE
ci: fix Dart Sass symlink — tarball binary is at dart-sass/sass

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -49,8 +49,14 @@ jobs:
           wget -qO /tmp/dart-sass.tar.gz \
             "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
           sudo tar -xzf /tmp/dart-sass.tar.gz -C /opt
-          sudo ln -sf /opt/dart-sass/dart-sass /usr/local/bin/dart-sass
+          # The tarball ships the binary at dart-sass/sass (not
+          # dart-sass/dart-sass). Symlink it under both names so that
+          # whichever Hugo invocation pattern (`sass` or `dart-sass`)
+          # is used, the binary is findable on PATH.
+          sudo ln -sf /opt/dart-sass/sass /usr/local/bin/sass
+          sudo ln -sf /opt/dart-sass/sass /usr/local/bin/dart-sass
           rm /tmp/dart-sass.tar.gz
+          sass --version
           dart-sass --version
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to PR #11. The tarball from `github.com/sass/dart-sass/releases` ships the executable at `dart-sass/sass`, not `dart-sass/dart-sass`. PR #11's symlink target assumed the latter; the build still failed with `dart-sass: command not found`.

Verified the actual layout:
```
$ tar -tzf dart-sass-1.79.4-linux-x64.tar.gz | head -4
dart-sass/src/LICENSE
dart-sass/src/dart
dart-sass/src/sass.snapshot
dart-sass/sass
```

Symlink the actual binary under both `sass` and `dart-sass` on PATH so that whichever invocation pattern Hugo's Sass pipeline uses, the binary is findable.

After this lands, re-trigger the failed deploy on master via `gh run rerun`.