### PR TITLE
Uniformize binding pages

### DIFF
--- a/content/bindings/gomeos.md
+++ b/content/bindings/gomeos.md
@@ -4,12 +4,10 @@ date: 2024-08-31T12:26:38+02:00
 draft: false
 ---
 
-GoMEOS is a Go library that wraps the MEOS C library using CGO, providing a set of Go functions that allows to use MEOS functionality by directly accessing C structs and C functions.
+GoMEOS is the Go binding for MEOS, wrapping the MEOS C library via CGO. It exposes MEOS types and functions for direct use in Go applications, suitable for backend services, data-pipeline workers, and command-line tools that consume or produce temporal data.
 
-GoMEOS exposes the functionality of MEOS and is meant to be used directly by the user.
+## Resources
 
-GitHub repository: https://github.com/MobilityDB/GoMEOS
-
-Examples: https://github.com/MobilityDB/GoMEOS/tree/main/examples
-
-Documentation: https://pkg.go.dev/github.com/MobilityDB/GoMEOS
+* GitHub: https://github.com/MobilityDB/GoMEOS
+* Documentation: https://pkg.go.dev/github.com/MobilityDB/GoMEOS
+* Examples: https://github.com/MobilityDB/GoMEOS/tree/main/examples

--- a/content/bindings/jmeos.md
+++ b/content/bindings/jmeos.md
@@ -4,10 +4,9 @@ date: 2024-08-31T12:13:56+02:00
 draft: false
 ---
 
-JMEOS: A Java binding of the MEOS spatiotemporal library
+JMEOS is the Java binding for MEOS, exposing the MEOS C API to JVM languages (Java, Kotlin, Scala, Clojure). Suitable for server-side JVM applications, Spark / Flink jobs that need temporal-type awareness, and any other JVM workload.
 
-Short description: TODO
+## Resources
 
-Link to API docs: https://mobilitydb.github.io/JMEOS/
-
-Github: https://github.com/MobilityDB/JMEOS
+* GitHub: https://github.com/MobilityDB/JMEOS
+* Documentation: https://mobilitydb.github.io/JMEOS/

--- a/content/bindings/meosjs.md
+++ b/content/bindings/meosjs.md
@@ -9,4 +9,6 @@ environments (via WebAssembly) and Node.js. Suitable for browser-side
 visualisations consuming trajectory data, Node.js services that
 manipulate temporal values, and any other JS workload.
 
-GitHub: https://github.com/MobilityDB/MEOS.js
+## Resources
+
+* GitHub: https://github.com/MobilityDB/MEOS.js

--- a/content/bindings/meosnet.md
+++ b/content/bindings/meosnet.md
@@ -9,4 +9,6 @@ as idiomatic .NET classes via P/Invoke. Suitable for desktop
 applications (WPF, WinForms, Avalonia), Unity games consuming
 trajectory data, ASP.NET services, and any other .NET workload.
 
-GitHub: https://github.com/MobilityDB/MEOS.NET
+## Resources
+
+* GitHub: https://github.com/MobilityDB/MEOS.NET

--- a/content/bindings/mobilitydb.md
+++ b/content/bindings/mobilitydb.md
@@ -11,8 +11,8 @@ integrates directly with [PostGIS](https://postgis.net/), so
 trajectories interoperate with conventional geometry / geography
 data without conversion.
 
-Project site: https://mobilitydb.com
+## Resources
 
-GitHub: https://github.com/MobilityDB/MobilityDB
-
-Documentation: https://docs.mobilitydb.com
+* Project site: https://mobilitydb.com
+* GitHub: https://github.com/MobilityDB/MobilityDB
+* Documentation: https://docs.mobilitydb.com

--- a/content/bindings/mobilityduck.md
+++ b/content/bindings/mobilityduck.md
@@ -10,4 +10,6 @@ types as first-class DuckDB types and is suited to analytics
 workloads — in-process queries, Parquet / Arrow interchange,
 notebook-driven exploration.
 
-GitHub: https://github.com/MobilityDB/MobilityDuck
+## Resources
+
+* GitHub: https://github.com/MobilityDB/MobilityDuck

--- a/content/bindings/pymeos.md
+++ b/content/bindings/pymeos.md
@@ -4,10 +4,9 @@ date: 2024-08-20T13:56:09+02:00
 draft: false
 ---
 
-PyMEOS contains the Python bindings of MEOS.
+PyMEOS is the Python binding for MEOS, exposing MEOS types as idiomatic Python classes via CFFI. Suitable for data-science workflows in Jupyter notebooks, integration with the Python data ecosystem (pandas, GeoPandas, MovingPandas), and any application code that manipulates temporal values.
 
-[comment]: <> (Short description and maybe installation process: TODO)
+## Resources
 
-Link to docs: https://pymeos.readthedocs.io/en/latest/
-
-Github: https://github.com/MobilityDB/PyMEOS
+* GitHub: https://github.com/MobilityDB/PyMEOS
+* Documentation: https://pymeos.readthedocs.io/


### PR DESCRIPTION
## Summary

The eight per-binding pages under `content/bindings/` had drifted into three different shapes:

- **PyMEOS** and **JMEOS** carried `TODO` placeholders left over from the original page scaffolding. JMEOS's was visible to readers; PyMEOS's was an HTML comment but still signalled incomplete work.
- **GoMEOS**, the four database / system pages, and PyMEOS / JMEOS used inline `Field: url` lines, with three different field-name conventions (`Github` / `GitHub` / `GitHub repository`).
- **meos-rs** has its own richer shape (badges + Overview + Key Features + Usage example), which is genuinely valuable and intentionally kept.

This PR uniformizes the surface without flattening the depth: every page now opens with one paragraph naming the binding, the host language / engine, the FFI idiom, and target use cases — followed by a `## Resources` section with consistently-named bullets (GitHub, Documentation, Project site, Examples).

## Per-page changes

| Page | Action |
|---|---|
| `pymeos.md` | Replaced HTML-comment TODO with opening + Resources block |
| `jmeos.md` | Replaced visible TODO with opening + Resources block (FFI-mechanism-neutral wording) |
| `gomeos.md` | Normalised opening + moved links into Resources section |
| `rustmeos.md` | **Untouched** — already the gold standard |
| `mobilitydb.md` | Inline links → Resources section |
| `mobilityduck.md` | Inline links → Resources section |
| `meosnet.md` | Inline links → Resources section |
| `meosjs.md` | Inline links → Resources section |

## Notes

- JMEOS opening is deliberately neutral about the FFI mechanism so the page stays correct across binding-internal refactors.
- meos-rs's existing shield badges already act as the equivalent of a Resources section, so adding a redundant `## Resources` heading there would be churn.
- Hugo build is clean (`hugo --quiet` produces no warnings or errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)