### PR TITLE
Document binding-page template in bindings index

### DIFF
--- a/content/bindings/_index.md
+++ b/content/bindings/_index.md
@@ -64,3 +64,13 @@ These bindings expose MEOS to general-purpose programming languages. Use them wh
 | target the browser or Node.js | MEOS.js |
 
 Bindings can be combined. A typical setup might use MobilityDB to store and query trajectories, PyMEOS to analyse them in a Jupyter notebook, and MEOS.js to visualise results in the browser. All three exchange data using MEOS's [encoding formats](/movingfeaturesformats/).
+
+## For binding contributors — page template
+
+Each binding has its own page in `content/bindings/`. Pages share a common template so readers moving between them see consistent structure:
+
+1. **Opening paragraph** — name the binding, the host language or query engine, the FFI idiom (CFFI, JNR-FFI, CGO, P/Invoke, WebAssembly, etc.), and one or two sentences on target use cases.
+2. **`## Resources` section** — a bulleted list with consistent field names: `GitHub`, `Documentation`, `Project site`, `Examples`. Include the fields that apply; omit the rest.
+3. **Optional richer sections** — `Overview`, `Installation`, `Usage example`, etc. Add them where there is content for them; absence is fine. The Rust page (`rustmeos.md`) is the example of a richer page that supplements rather than conflicts with the template.
+
+When writing the opening paragraph, keep wording neutral about implementation details that may change across binding-internal refactors (concrete FFI library, dependency versions, etc.).


### PR DESCRIPTION
## Summary

Follow-up to #13. Captures the binding-page template as
contributor-visible documentation in \`content/bindings/_index.md\`,
so future binding pages follow the same structure without page-by-page
enforcement.

Three-step template:

1. Opening paragraph — name + language/engine + FFI idiom + use cases
2. \`## Resources\` section — bulleted list with consistent field names (GitHub, Documentation, Project site, Examples)
3. Optional richer sections — Overview, Installation, Usage example, etc. (rustmeos.md is the example of a richer page)

Plus a wording note: keep neutral about implementation details that may change across binding-internal refactors (FFI library, dependency versions). Captured from the JMEOS case in #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)